### PR TITLE
Add Support for Multiple Pressure Level Requests in 'create_filename'

### DIFF
--- a/CDS_retriever.py
+++ b/CDS_retriever.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import datetime
 import cdsapi
 from cdo import Cdo, CDOException
+from config import validate_levelout_get_unit
+
 cdo = Cdo()
 
 
@@ -281,16 +283,52 @@ def define_time(freq):
 
     return product_type, day, time, time_kind, minimum_steps
 
-# create filename function
+
+
 def create_filename(dataset, var, freq, grid, levelout, area, year1, year2=None):
-    """Create the final output file"""
+    """
+    Generate a filename based on the provided parameters.
+
+    Parameters:
+        dataset (str): The name of the dataset.
+        var (str): The variable name.
+        freq (str): The temporal frequency of the data ('instant', '1hr', '6hrs', 'mon'.).
+        grid (str): The grid specification ('full', '0.1x0.1', '0.25x0.25', '2.5x2.5'.).
+        levelout (str or list of str): The pressure levels, either as a single string 
+            (e.g., '500hPa') or a list of strings (e.g., ['500hPa', '700hPa']).
+            If the `levelout` is a list of pressure levels 'hPa' will be stripped 
+            from individual levels and appended to the final concatenated string.
+        area (str or list of str): The geographic area. If 'global', no area is added to the filename.
+            If a list of coordinates in the North, West, South, East order
+            is provided, it will be joined by underscores.
+        year1 (str): The starting year.
+        year2 (str, optional): The ending year.
+
+    Returns:
+        str: The generated filename following the convention:
+            `<dataset>_<var>_<freq>_<grid>_<levelout>_<year1>[-<year2>]_[area]`.
+
+    """
+
+    unit = validate_levelout_get_unit(levelout)
+
+    # Format levelout properly if it is provided as a list
+    if isinstance(levelout,list):
+        cleaned_levels = [level.replace('hPa', '') for level in levelout]
+        levelout = '-'.join(cleaned_levels) + unit
+
+    # Generate the base filename
     filename = dataset + '_' + var + '_' + freq + '_' + grid + '_' + levelout + '_' + year1
+    
     if (freq == 'mon') and (year2 is not None):
         filename = filename + '-' + year2
     if area != 'global':
         strarea = "_".join([str(x) for x in area])
         filename = filename + '_' + strarea
+
     return filename
+
+
 
 # wrapper for simple parallel function for conversion to netcdf
 def year_convert(infile, outfile, debug=False):

--- a/config.tmpl
+++ b/config.tmpl
@@ -13,7 +13,8 @@ year :
 freq : 'mon'    # Data frequency. Available options: 'instant', '1hr', '6hrs', 'mon'.
                 # Beware of 'instant'. 'mon' gets monthly means.
 levelout : 'sfc'    # Vertical levels. Available option: 'sfc', 'plev37', 'plev19', 'plev8'.
-                    # For single pressure level vars levelout = '500hPa'.
+                    # For specific pressure level(s) levelout = '500hPa',
+                    # or list, e.g. levelout = ['500hPa', '700hPa', '850hPa'].
 grid : 'full'    # Grid selection. Available options: 'full', '0.1x0.1', '0.25x0.25', '2.5x2.5'.
                  # 'full' = no choiche is made, i.e. the original grid is provided
 area : 'global'    # Either 'global' or a list of coordinates in the North, West, South, East order (e.g. [65, -15, 25, 45])


### PR DESCRIPTION
## Summary of Changes:
1. **Function Update:** The `create_filename` function has been updated to support multiple pressure level requests. It now handles cases where `levelout` is a list of pressure levels, formatting them properly and appending the unit of measure accordingly.
2. **New Validation Function:** A new function `validate_levelout_get_unit` has been added to the `config.py` module. This function checks whether the `levelout` specified in the configuration file is valid and returns the appropriate unit of measure.
3. **Integration with `create_filename`:** The output of the new validation function is used in `create_filename` to manage cases where the user requests multiple pressure levels, provided as a list.
4. **Updated User Config Template:** The `config.tmpl` file has been updated to explicitly indicate that users can specify multiple pressure levels as a list.

Docstrings have been added where necessary.